### PR TITLE
Update lambda_decorators.py

### DIFF
--- a/lambda_decorators.py
+++ b/lambda_decorators.py
@@ -204,8 +204,8 @@ class LambdaDecorator(object):
         {'statusCode': 500, 'body': 'uh oh, you broke it'}
     """
     def __init__(self, handler):
-        self.handler = handler
         update_wrapper(self, handler)
+        self.handler = handler
 
     def __call__(self, event, context):
         try:


### PR DESCRIPTION
Chatted online, but recapping:

**Problem:** Implementing multiple `LambdaDecorator` subclasses with `before()` was only running through one of them.

**Solution:** In the `__init__()` method of `LambdaDecorator`, run the `update_wrapper()` function on the handler before assigning it to the `self.handler` of the class. I have no idea _why_ this works, but it does.

**Repro steps:**

1. Add this file locally as `handler.py`:

```python
import json
from lambda_decorators import LambdaDecorator

class structlogger(LambdaDecorator):
    def before(self, event, context):
        print('Doing structlog...')

        return event, context


class database(LambdaDecorator):
    def before(self, event, context):
        print('Doing database...')

        return event, context


@structlogger
@database
def hello(event, context):
    body = {
        "message": "Go Serverless v1.0! Your function executed successfully!",
        "input": event
    }

    response = {
        "statusCode": 200,
        "body": json.dumps({'message': 'Hello'})
    }

    return response


if __name__ == "__main__":
    hello("", "")
```

2. Curl the `lambda-decorators` file into your directory:

```bash
$ curl -O https://raw.githubusercontent.com/dschep/lambda-decorators/master/lambda_decorators.py
```

3. Run the file:

```bash
$ python handler.py
Doing structlog...
```

Notice that it only printed the statement from the first decorator.

4. Pull this file in, or swap lines 207 & 208 in `lambda_decorators.py`.

5. Run it again:

```bash
$ python handler.py
Doing structlog...
Doing database...
```

Both of them run 🤔 