### PR TITLE
`secrets_manager` works if secret isn't json

### DIFF
--- a/lambda_decorators.py
+++ b/lambda_decorators.py
@@ -799,9 +799,12 @@ def secrets_manager(*secret_names):
                     service_name="secretsmanager"
                 ).get_secret_value(SecretId=secret_name)
                 if "SecretString" in secret_value:
-                    context.secrets[secret_name] = json.loads(
-                        secret_value["SecretString"]
-                    )
+                    try:
+                        context.secrets[secret_name] = json.loads(
+                            secret_value["SecretString"]
+                        )
+                    except:
+                        context.secrets[secret_name] = secret_value["SecretString"]
                 else:
                     context.secrets[secret_name] = secret_value["SecretBinary"]
 


### PR DESCRIPTION
While encouraged to be a valid json object, the secrets manager doesn't actually enforce that the secrets are json.

This PR first tries to decode the json, and if it fails it will return the plain text secret isntead.